### PR TITLE
Fix bug: manually setRefreshing doesn't work

### DIFF
--- a/swiperefreshlayoutbottomlib/src/main/java/android/support/library21/custom/SwipeRefreshLayoutBottom.java
+++ b/swiperefreshlayoutbottomlib/src/main/java/android/support/library21/custom/SwipeRefreshLayoutBottom.java
@@ -348,7 +348,7 @@ public class SwipeRefreshLayoutBottom extends ViewGroup {
             } else {
                 endTarget = (int) mSpinnerFinalOffset;
             }
-            setTargetOffsetTopAndBottom(endTarget - mCurrentTargetOffsetTop,
+            setTargetOffsetTopAndBottom(mCurrentTargetOffsetTop - endTarget,
                     true /* requires update */);
             mNotify = false;
             startScaleUpAnimation(mRefreshListener);


### PR DESCRIPTION
When calling setRefreshing(true) to the original SwipeRefreshLayout, the circle will appear. But SwipeRefreshLayoutBottom doesn't. The reason is the y offset is wrong.